### PR TITLE
Added support specifying azure user Assigned identity(clientId) for c…

### DIFF
--- a/pkg/scalers/azure/azure_eventhub.go
+++ b/pkg/scalers/azure/azure_eventhub.go
@@ -18,6 +18,7 @@ type EventHubInfo struct {
 	EventHubConnection       string
 	EventHubConsumerGroup    string
 	StorageConnection        string
+	// +optional
 	StorageAccountName       string
 	BlobStorageEndpoint      string
 	BlobContainer            string
@@ -27,6 +28,8 @@ type EventHubInfo struct {
 	ServiceBusEndpointSuffix string
 	ActiveDirectoryEndpoint  string
 	EventHubResourceURL      string
+	// +optional
+	CheckpointIdentityId     string
 	PodIdentity              kedav1alpha1.AuthPodIdentity
 }
 

--- a/pkg/scalers/azure/azure_eventhub_checkpoint.go
+++ b/pkg/scalers/azure/azure_eventhub_checkpoint.go
@@ -231,6 +231,10 @@ func getCheckpoint(ctx context.Context, httpClient util.HTTPDoer, info EventHubI
 		podIdentity.Provider = kedav1alpha1.PodIdentityProviderNone
 	}
 
+	if len(info.CheckpointIdentityId) != 0 {
+		podIdentity.IdentityID = info.CheckpointIdentityId
+	}
+
 	if podIdentity.Provider == kedav1alpha1.PodIdentityProviderAzure || podIdentity.Provider == kedav1alpha1.PodIdentityProviderAzureWorkload {
 		if len(info.StorageAccountName) == 0 {
 			return Checkpoint{}, fmt.Errorf("storageAccountName not supplied when PodIdentity authentication is enabled")

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -213,7 +213,7 @@ func parseAzureEventHubAuthenticationMetadata(logger logr.Logger, config *Scaler
 		if val, ok := config.TriggerMetadata["CheckpointIdentity"]; ok {
 			meta.eventHubInfo.CheckpointIdentityId = val
 		} else {
-			logger.Info("no 'CheckpointIdentity' supplied to enable identity based authentication to Blob Storage. Using Pod Identity instead or connection string instead if no 'storageAccountName' supplied")
+			logger.Info("no 'CheckpointIdentityId' supplied to enable identity based authentication to Blob Storage. Using Pod Identity or connection string instead if no 'storageAccountName' supplied")
 		}
 
 		if len(meta.eventHubInfo.StorageAccountName) != 0 {

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -210,6 +210,12 @@ func parseAzureEventHubAuthenticationMetadata(logger logr.Logger, config *Scaler
 			logger.Info("no 'storageAccountName' provided to enable identity based authentication to Blob Storage. Attempting to use connection string instead")
 		}
 
+		if val, ok := config.TriggerMetadata["CheckpointIdentity"]; ok {
+			meta.eventHubInfo.CheckpointIdentityId = val
+		} else {
+			logger.Info("no 'CheckpointIdentity' supplied to enable identity based authentication to Blob Storage. Using Pod Identity instead or connection string instead if no 'storageAccountName' supplied")
+		}
+
 		if len(meta.eventHubInfo.StorageAccountName) != 0 {
 			storageEndpointSuffixProvider := func(env az.Environment) (string, error) {
 				return env.StorageEndpointSuffix, nil

--- a/pkg/scalers/azure_eventhub_scaler_test.go
+++ b/pkg/scalers/azure_eventhub_scaler_test.go
@@ -28,6 +28,7 @@ const (
 	testEventHubName          = "eventhub1"
 	checkpointFormat          = "{\"SequenceNumber\":%d,\"PartitionId\":\"%s\"}"
 	testContainerName         = "azure-webjobs-eventhub"
+	checkpointIdentityId      = "checkpoint-guid"
 )
 
 type parseEventHubMetadataTestData struct {
@@ -101,6 +102,8 @@ var parseEventHubMetadataDatasetWithPodIdentity = []parseEventHubMetadataTestDat
 	{map[string]string{"cloud": "private", "storageAccountName": "blobstorage", "consumerGroup": eventHubConsumerGroup, "unprocessedEventThreshold": "15", "eventHubName": testEventHubName, "eventHubNamespace": testEventHubNamespace}, true},
 	// properly formed event hub metadata with Pod Identity and no storage connection string, private cloud and storageEndpointSuffix
 	{map[string]string{"cloud": "private", "endpointSuffix": serviceBusEndpointSuffix, "activeDirectoryEndpoint": activeDirectoryEndpoint, "eventHubResourceURL": eventHubResourceURL, "storageAccountName": "aStorageAccount", "storageEndpointSuffix": storageEndpointSuffix, "consumerGroup": eventHubConsumerGroup, "unprocessedEventThreshold": "15", "eventHubName": testEventHubName, "eventHubNamespace": testEventHubNamespace}, false},
+	// properly formed event hub metadata with checkpointIdentity
+	{map[string]string{"storageAccountName": "blobstorage", "consumerGroup": eventHubConsumerGroup, "unprocessedEventThreshold": "15", "eventHubName": testEventHubName, "eventHubNamespace": testEventHubNamespace, "CheckpointIdentityId": checkpointIdentityId}, false},
 }
 
 var eventHubMetricIdentifiers = []eventHubMetricIdentifier{


### PR DESCRIPTION
Added support specifying azure user assigned identity (clientId) for checkpointing (Azure Storage Account). This allows users to specify a different Identity for checkpointing (optional) as part of the event hub info metadata.

