### PR TITLE
Added support for multi-tenant access with AAD workload identities

### DIFF
--- a/apis/keda/v1alpha1/triggerauthentication_types.go
+++ b/apis/keda/v1alpha1/triggerauthentication_types.go
@@ -114,9 +114,11 @@ const (
 // AuthPodIdentity allows users to select the platform native identity
 // mechanism
 type AuthPodIdentity struct {
-	Provider PodIdentityProvider `json:"provider"`
+	Provider   PodIdentityProvider `json:"provider"`
 	// +optional
 	IdentityID string `json:"identityId"`
+	// +optional
+	TenantID   string `json:"tenantId"`
 }
 
 // AuthSecretTargetRef is used to authenticate using a reference to a secret

--- a/config/crd/bases/keda.sh_clustertriggerauthentications.yaml
+++ b/config/crd/bases/keda.sh_clustertriggerauthentications.yaml
@@ -190,6 +190,8 @@ spec:
                   provider:
                     description: PodIdentityProvider contains the list of providers
                     type: string
+                  tenantId:
+                    type: string
                 required:
                 - provider
                 type: object

--- a/config/crd/bases/keda.sh_triggerauthentications.yaml
+++ b/config/crd/bases/keda.sh_triggerauthentications.yaml
@@ -189,6 +189,8 @@ spec:
                   provider:
                     description: PodIdentityProvider contains the list of providers
                     type: string
+                  tenantId:
+                    type: string
                 required:
                 - provider
                 type: object

--- a/pkg/scalers/azure/azure_eventhub.go
+++ b/pkg/scalers/azure/azure_eventhub.go
@@ -29,7 +29,9 @@ type EventHubInfo struct {
 	ActiveDirectoryEndpoint  string
 	EventHubResourceURL      string
 	// +optional
-	CheckpointIdentityId     string
+	CheckpointIdentityID     string
+	// +optional
+	CheckpointTenantID       string
 	PodIdentity              kedav1alpha1.AuthPodIdentity
 }
 
@@ -70,7 +72,7 @@ func GetEventHubClient(ctx context.Context, info EventHubInfo) (*eventhub.Hub, e
 		// User wants to use AAD Workload Identity
 		env := azure.Environment{ActiveDirectoryEndpoint: info.ActiveDirectoryEndpoint, ServiceBusEndpointSuffix: info.ServiceBusEndpointSuffix}
 		hubEnvOptions := eventhub.HubWithEnvironment(env)
-		provider := NewAzureADWorkloadIdentityTokenProvider(ctx, info.PodIdentity.IdentityID, info.EventHubResourceURL)
+		provider := NewAzureADWorkloadIdentityTokenProvider(ctx, info.PodIdentity.IdentityID, info.PodIdentity.TenantID, info.EventHubResourceURL)
 
 		return eventhub.NewHub(info.Namespace, info.EventHubName, provider, hubEnvOptions)
 	}

--- a/pkg/scalers/azure/azure_eventhub_checkpoint.go
+++ b/pkg/scalers/azure/azure_eventhub_checkpoint.go
@@ -231,8 +231,12 @@ func getCheckpoint(ctx context.Context, httpClient util.HTTPDoer, info EventHubI
 		podIdentity.Provider = kedav1alpha1.PodIdentityProviderNone
 	}
 
-	if len(info.CheckpointIdentityId) != 0 {
-		podIdentity.IdentityID = info.CheckpointIdentityId
+	if len(info.CheckpointIdentityID) != 0 {
+		podIdentity.IdentityID = info.CheckpointIdentityID
+	}
+
+	if len(info.CheckpointTenantID) != 0 {
+		podIdentity.TenantID = info.CheckpointTenantID
 	}
 
 	if podIdentity.Provider == kedav1alpha1.PodIdentityProviderAzure || podIdentity.Provider == kedav1alpha1.PodIdentityProviderAzureWorkload {

--- a/pkg/scalers/azure/azure_storage.go
+++ b/pkg/scalers/azure/azure_storage.go
@@ -201,7 +201,7 @@ func parseAccessTokenAndEndpoint(ctx context.Context, httpClient util.HTTPDoer, 
 	case kedav1alpha1.PodIdentityProviderAzure:
 		token, err = GetAzureADPodIdentityToken(ctx, httpClient, podIdentity.IdentityID, storageResource)
 	case kedav1alpha1.PodIdentityProviderAzureWorkload:
-		token, err = GetAzureADWorkloadIdentityToken(ctx, podIdentity.IdentityID, storageResource)
+		token, err = GetAzureADWorkloadIdentityToken(ctx, podIdentity.IdentityID, podIdentity.TenantID, storageResource)
 	}
 
 	if err != nil {

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -210,10 +210,16 @@ func parseAzureEventHubAuthenticationMetadata(logger logr.Logger, config *Scaler
 			logger.Info("no 'storageAccountName' provided to enable identity based authentication to Blob Storage. Attempting to use connection string instead")
 		}
 
-		if val, ok := config.TriggerMetadata["checkpointIdentityId"]; ok {
-			meta.eventHubInfo.CheckpointIdentityId = val
+		if val, ok := config.TriggerMetadata["checkpointIdentityID"]; ok {
+			meta.eventHubInfo.CheckpointIdentityID = val
 		} else {
 			logger.Info("no 'CheckpointIdentityId' supplied to enable identity based authentication to Blob Storage. Using Pod Identity or connection string instead if no 'storageAccountName' supplied")
+		}
+
+		if val, ok := config.TriggerMetadata["checkpointTenantID"]; ok {
+			meta.eventHubInfo.CheckpointTenantID = val
+		} else {
+			logger.Info("no 'CheckpointTenantID' supplied to enable identity based authentication to Blob Storage. Using Default TenantId configured in the storage account instead")
 		}
 
 		if len(meta.eventHubInfo.StorageAccountName) != 0 {

--- a/pkg/scalers/azure_eventhub_scaler_test.go
+++ b/pkg/scalers/azure_eventhub_scaler_test.go
@@ -28,7 +28,7 @@ const (
 	testEventHubName          = "eventhub1"
 	checkpointFormat          = "{\"SequenceNumber\":%d,\"PartitionId\":\"%s\"}"
 	testContainerName         = "azure-webjobs-eventhub"
-	checkpointIdentityId      = "checkpoint-guid"
+	checkpointIdentityID      = "checkpoint-guid"
 )
 
 type parseEventHubMetadataTestData struct {
@@ -102,8 +102,8 @@ var parseEventHubMetadataDatasetWithPodIdentity = []parseEventHubMetadataTestDat
 	{map[string]string{"cloud": "private", "storageAccountName": "blobstorage", "consumerGroup": eventHubConsumerGroup, "unprocessedEventThreshold": "15", "eventHubName": testEventHubName, "eventHubNamespace": testEventHubNamespace}, true},
 	// properly formed event hub metadata with Pod Identity and no storage connection string, private cloud and storageEndpointSuffix
 	{map[string]string{"cloud": "private", "endpointSuffix": serviceBusEndpointSuffix, "activeDirectoryEndpoint": activeDirectoryEndpoint, "eventHubResourceURL": eventHubResourceURL, "storageAccountName": "aStorageAccount", "storageEndpointSuffix": storageEndpointSuffix, "consumerGroup": eventHubConsumerGroup, "unprocessedEventThreshold": "15", "eventHubName": testEventHubName, "eventHubNamespace": testEventHubNamespace}, false},
-	// properly formed event hub metadata with checkpointIdentityId
-	{map[string]string{"storageAccountName": "blobstorage", "consumerGroup": eventHubConsumerGroup, "unprocessedEventThreshold": "15", "eventHubName": testEventHubName, "eventHubNamespace": testEventHubNamespace, "checkpointIdentityId": checkpointIdentityId}, false},
+	// properly formed event hub metadata with checkpointIdentityID
+	{map[string]string{"storageAccountName": "blobstorage", "consumerGroup": eventHubConsumerGroup, "unprocessedEventThreshold": "15", "eventHubName": testEventHubName, "eventHubNamespace": testEventHubNamespace, "checkpointIdentityID": checkpointIdentityID}, false},
 }
 
 var eventHubMetricIdentifiers = []eventHubMetricIdentifier{

--- a/pkg/scalers/azure_log_analytics_scaler.go
+++ b/pkg/scalers/azure_log_analytics_scaler.go
@@ -510,7 +510,7 @@ func (s *azureLogAnalyticsScaler) getAuthorizationToken(ctx context.Context) (to
 
 	switch s.metadata.podIdentity.Provider {
 	case kedav1alpha1.PodIdentityProviderAzureWorkload:
-		aadToken, err := azure.GetAzureADWorkloadIdentityToken(ctx, s.metadata.podIdentity.IdentityID, s.metadata.logAnalyticsResourceURL)
+		aadToken, err := azure.GetAzureADWorkloadIdentityToken(ctx, s.metadata.podIdentity.IdentityID, s.metadata.podIdentity.TenantID, s.metadata.logAnalyticsResourceURL)
 		if err != nil {
 			return tokenData{}, nil
 		}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] Tests have been added
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
